### PR TITLE
메타데이터 추가

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,7 @@ module.exports = {
   jsxRuntime: 'automatic',
   siteMetadata: {
     title: 'Jin\'s log',
-    siteUrl: 'https://www.yourdomain.tld',
+    siteUrl: 'https://gringrape.github.io/',
   },
   plugins: ['gatsby-plugin-styled-components', 'gatsby-plugin-mdx', {
     resolve: 'gatsby-source-filesystem',

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -21,3 +21,9 @@ function IndexPage() {
 }
 
 export default IndexPage;
+
+export function Head() {
+  return (
+    <title>Jin wiki</title>
+  );
+}

--- a/src/pages/{MarkdownRemark.frontmatter__slug}.jsx
+++ b/src/pages/{MarkdownRemark.frontmatter__slug}.jsx
@@ -32,3 +32,5 @@ export const PostQuery = graphql`
     }
   }
 `;
+
+export { Head } from './index';


### PR DESCRIPTION
타이틀과 같은 메타데이터를 변경하고 페이지마다 표시하도록 함.

`Gatsby`의 `SEO component` 기능을 활용함.

docs: https://www.gatsbyjs.com/docs/reference/built-in-components/gatsby-head/